### PR TITLE
Change to Neo motors

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -34,9 +34,7 @@ public final class Constants {
   public static class IntakeConstants {
     public static final int IntakeMotorID = 13;
     public static final double IntakeFeederSpeed = -1.0; // -.2;
-
-    // Do we need this?
-    public static final int kFeedCurrentLimit = 80;
+    public static final int CurrentLimit = 80;
   }
 
   public static class LauncherConstants {
@@ -44,24 +42,25 @@ public final class Constants {
     public static final int kLauncherLeftyID = 11;
     public static final int kLauncherRightyID = 12;
 
-    // Current limit for launcher and feed wheels
     public static final int kLauncherCurrentLimit = 80;
 
-    // Speeds for wheels when intaking and launching. Intake speeds are negative to run the wheels
-    // in reverse
+    // Speeds for wheels when intaking and launching
+    //  Intake speeds could be negative to run the wheels in reverse
     public static final double kLauncherSpeed = 1;
     public static final double kLaunchFeederSpeed = 1;
     public static final double kLauncherDelay = 1;
   }
 
-  public static class LifterConstants {
+  public static class LauncherArmConstants {
     public static final int kRightLifterID = 8;
     public static final int kLeftLifterID = 5;
+    public static int CurrentLimit = 80;
   }
   public static class ClawConstants{
     //these are sample numbers, they may need to be adjusted later as they are not the real numbers. 
     public static final int kRightClaw = 100;
-    public static final int kLeftClaw = 110;
+    public static final int kLeftClaw = 110;    
+    public static int CurrentLimit = 80;
   }
   
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -94,16 +94,7 @@ public class RobotContainer {
   }
 
   private void configureDrivetrainBindings() {
-    // m_drivetrain.setDefaultCommand(
-    //     new RunCommand(
-    //         () ->
-    //             m_drivetrain.arcadeDrive(
-    //                 m_driverController.getRightX(),
-    //                 m_driverController
-    //                     .getLeftY()), // For 2024 we had to swap Y & X to map properly to the XBox
-    //         // controller joysticks
-    //         m_drivetrain));
-
+    
     swerve.drivetrain.setDefaultCommand( // Drivetrain will execute this command periodically
         swerve.drivetrain.applyRequest(() -> 
           swerve.drive.withVelocityX(-m_driverController.getLeftY() * swerve.MaxSpeed) // Drive forward with negative Y (forward)

--- a/src/main/java/frc/robot/subsystems/Claw.java
+++ b/src/main/java/frc/robot/subsystems/Claw.java
@@ -4,34 +4,30 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ClawConstants;
-import frc.robot.Constants.LifterConstants;
 
+/** Subsystem for the lifter-in-a-box component */
 public class Claw extends SubsystemBase {
-  WPI_TalonSRX m_spin1;
-  WPI_TalonSRX m_spin2;
+  private CANSparkMax m_spin1;
+  private CANSparkMax m_spin2;
 
-  /** Creates a new Launcher. */
-  //We need two new constants for this...
   public Claw() {
-    //Here we declare the two new spin motors
      
-    m_spin1 = new WPI_TalonSRX(ClawConstants.kRightClaw);
-    m_spin2 = new WPI_TalonSRX(ClawConstants.kLeftClaw);
+    m_spin1 = new CANSparkMax(ClawConstants.kRightClaw, MotorType.kBrushless);
+    m_spin2 = new CANSparkMax(ClawConstants.kLeftClaw, MotorType.kBrushless);
 
     m_spin2.follow(m_spin1);
 
-    // m_launchWheel.setSmartCurrentLimit(kLauncherCurrentLimit);
-    // m_feedWheel.setSmartCurrentLimit(kFeedCurrentLimit);
-    
+    m_spin1.setSmartCurrentLimit(ClawConstants.CurrentLimit);
+    m_spin2.setSmartCurrentLimit(ClawConstants.CurrentLimit);
   }
- 
-
- public Command getClawUp() {
+  
+  public Command getClawUp() {
     return this.startEnd(
         () -> {
           m_spin1.set(1.0);
@@ -54,8 +50,5 @@ public class Claw extends SubsystemBase {
           m_spin2.set(0);
         });
 
-
       }
-
-
 }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -4,20 +4,20 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkLowLevel.MotorType;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.IntakeConstants;
 
 public class Intake extends SubsystemBase {
-  WPI_TalonSRX m_intake;
+  private CANSparkMax m_intake;
 
   /** Creates a new Launcher. */
   public Intake() {
-    m_intake = new WPI_TalonSRX(IntakeConstants.IntakeMotorID);
-
-    // m_launchWheel.setSmartCurrentLimit(kLauncherCurrentLimit);
-    // m_feedWheel.setSmartCurrentLimit(kFeedCurrentLimit);
+    m_intake = new CANSparkMax(IntakeConstants.IntakeMotorID, MotorType.kBrushless);
+    m_intake.setSmartCurrentLimit(IntakeConstants.CurrentLimit);
   }
 
   /**
@@ -48,8 +48,6 @@ public class Intake extends SubsystemBase {
         // When the command is initialized, set the wheels to the intake speed values
         () -> {
           setFeedWheel(-IntakeConstants.IntakeFeederSpeed);
-          // m_feedWheel_lower.set(kIntakeFeederSpeed);
-          //  setLaunchWheel(kIntakeLauncherSpeed);
         },
         // When the command stops, stop the wheels
         () -> {

--- a/src/main/java/frc/robot/subsystems/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/Launcher.java
@@ -4,24 +4,26 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkLowLevel.MotorType;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.LauncherConstants;
 
 public class Launcher extends SubsystemBase {
-  WPI_TalonSRX m_lefty;
-  WPI_TalonSRX m_righty;
+  private CANSparkMax m_left;
+  private CANSparkMax m_right;
 
   /** Creates a new Launcher. */
   public Launcher() {
-    m_lefty = new WPI_TalonSRX(LauncherConstants.kLauncherLeftyID);
-    m_righty = new WPI_TalonSRX(LauncherConstants.kLauncherRightyID);
+    m_left = new CANSparkMax(LauncherConstants.kLauncherLeftyID, MotorType.kBrushless);
+    m_right = new CANSparkMax(LauncherConstants.kLauncherRightyID, MotorType.kBrushless);
 
-    m_lefty.follow(m_righty);
+    m_left.follow(m_right);
 
-    // m_launchWheel.setSmartCurrentLimit(kLauncherCurrentLimit);
-    // m_feedWheel.setSmartCurrentLimit(kFeedCurrentLimit);
+    m_left.setSmartCurrentLimit(LauncherConstants.kLauncherCurrentLimit);
+    m_right.setSmartCurrentLimit(LauncherConstants.kLauncherCurrentLimit);
   }
 
   public Command getlaunchCommand(double speed) {
@@ -29,14 +31,14 @@ public class Launcher extends SubsystemBase {
   }
 
   public void setMotorSpeed(double speed) {
-    m_lefty.set(-speed);
-    m_righty.set(speed);
+    m_left.set(-speed);
+    m_right.set(speed);
   }
 
   // A helper method to stop both wheels. You could skip having a method like this and call the
   // individual accessors with speed = 0 instead
   public void stop() {
-    m_lefty.set(0);
-    m_righty.set(0);
+    m_left.set(0);
+    m_right.set(0);
   }
 }

--- a/src/main/java/frc/robot/subsystems/LauncherArm.java
+++ b/src/main/java/frc/robot/subsystems/LauncherArm.java
@@ -1,44 +1,49 @@
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkLowLevel.MotorType;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants.LifterConstants;
+import frc.robot.Constants.LauncherArmConstants;
 
 public class LauncherArm extends SubsystemBase {
 
-  WPI_TalonSRX m_lifter_left;
-  WPI_TalonSRX m_lifter_right;
+  private CANSparkMax m_left;
+  private CANSparkMax m_right;
 
   public LauncherArm() {
 
-    m_lifter_left = new WPI_TalonSRX(LifterConstants.kLeftLifterID);
-    m_lifter_right = new WPI_TalonSRX(LifterConstants.kRightLifterID);
+    m_left = new CANSparkMax(LauncherArmConstants.kLeftLifterID, MotorType.kBrushless);
+    m_right = new CANSparkMax(LauncherArmConstants.kRightLifterID, MotorType.kBrushless);
 
-    m_lifter_left.follow(m_lifter_right);
+    m_left.follow(m_right);
+
+    m_left.setSmartCurrentLimit(LauncherArmConstants.CurrentLimit);
+    m_right.setSmartCurrentLimit(LauncherArmConstants.CurrentLimit);
   }
 
   public Command getLauncherUpCommand() {
     return this.startEnd(
         () -> {
-          m_lifter_left.set(1.0);
-          m_lifter_right.set(-1.0);
+          m_left.set(1.0);
+          m_right.set(-1.0);
         },
         () -> {
-          m_lifter_left.set(0);
-          m_lifter_right.set(0);
+          m_left.set(0);
+          m_right.set(0);
         });
   }
 
   public Command getLauncherDownCommand() {
     return this.startEnd(
         () -> {
-          m_lifter_left.set(-1.0);
-          m_lifter_right.set(1.0);
+          m_left.set(-1.0);
+          m_right.set(1.0);
         },
         () -> {
-          m_lifter_left.set(0);
-          m_lifter_right.set(0);
+          m_left.set(0);
+          m_right.set(0);
         });
   }
 }

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2024.0.0",
+    "version": "2024.2.1",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2024.0.0"
+            "version": "2024.2.1"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.0.0",
+            "version": "2024.2.1",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2024.0.0",
+            "version": "2024.2.1",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.0.0",
+            "version": "2024.2.1",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Apply new motor/encoder types from Phoenix/Talon to Neo/SparkMax. `WPI_TalonSRX` can be found in branch Arcade-Drive-Robot.